### PR TITLE
Add type annotations and docstrings to sim_db CRUD functions

### DIFF
--- a/sim_db.py
+++ b/sim_db.py
@@ -9,32 +9,43 @@ version: 1.0
 __doc__ = 'simple database for simulations and more (based on pandas and include CRUD)'
 
 import os
+from typing import Any, Mapping
+
 import pandas as pd
 
-def create_csv_db(fn_csv, dic):
-    if os.path.exists(fn_csv): raise Exception(f'{fn_csv} already created, you can add items!')
+
+def create_csv_db(fn_csv: str, dic: Mapping[str, Mapping[str, Any]]) -> None:
+    """Create a new CSV-backed simulation database from a mapping of case records."""
+    if os.path.exists(fn_csv):
+        raise Exception(f'{fn_csv} already created, you can add items!')
     df = pd.DataFrame.from_dict(dic, orient='index')
     df.to_csv(fn_csv)
     print(f'mini sim database: {fn_csv}, created! CREATE table')
 
-def add_cases(fn_csv, sim_cases):
+
+def add_cases(fn_csv: str, sim_cases: Mapping[str, Mapping[str, Any]]) -> None:
+    """Insert new simulation cases into an existing CSV database."""
     df = pd.read_csv(fn_csv, index_col=0)
     for cas, detail in sim_cases.items():
-        if cas in df.index: 
+        if cas in df.index:
             print(f'{cas} already in db (key), skip')
         else:
             df.loc[cas] = detail
     df.to_csv(fn_csv)
     print(f'mini sim database: {fn_csv}, updated! INSERT {len(sim_cases)} items, now total {len(df)} items')
 
-def add_case_info(fn_csv, new_info, case_val_d):
+
+def add_case_info(fn_csv: str, new_info: str, case_val_d: Mapping[str, Any]) -> None:
+    """Add a new column with per-case values for known case IDs."""
     df = pd.read_csv(fn_csv, index_col=0)
     df[new_info] = case_val_d
     df.to_csv(fn_csv)
     print(f"new info '{new_info}' added!")
     print(df[new_info])
 
-def upd_cases(fn_csv, sim_cases_new_info):
+
+def upd_cases(fn_csv: str, sim_cases_new_info: Mapping[str, Mapping[str, Any]]) -> None:
+    """Update existing simulation cases with partial column/value mappings."""
     df = pd.read_csv(fn_csv, index_col=0)
     for cas, detail in sim_cases_new_info.items():
         if cas not in df.index:
@@ -46,10 +57,12 @@ def upd_cases(fn_csv, sim_cases_new_info):
     df.to_csv(fn_csv)
     print(f'mini sim database: {fn_csv}, updated! UPDATE {len(sim_cases_new_info)} sim cases')
 
-def del_cases(fn_csv, sim_case_list):
+
+def del_cases(fn_csv: str, sim_case_list: list[str]) -> None:
+    """Delete simulation cases by case IDs from the CSV database."""
     df = pd.read_csv(fn_csv, index_col=0)
     for cas in sim_case_list:
-        if cas in df.index: 
+        if cas in df.index:
             df = df.drop(cas)
             print(f'{cas} delete in db')
         else:
@@ -57,26 +70,37 @@ def del_cases(fn_csv, sim_case_list):
     df.to_csv(fn_csv)
     print(f'mini sim database: {fn_csv}, changed! DELETE {len(sim_case_list)} items, now total {len(df)} items')
 
-def list_case_info(fn_csv):
+
+def list_case_info(fn_csv: str) -> pd.DataFrame:
+    """Print and return available column names for the simulation database."""
     df = pd.read_csv(fn_csv, index_col=0)
     print(df.columns)
     return df
 
-def list_sim_db(fn_csv):
+
+def list_sim_db(fn_csv: str) -> pd.DataFrame:
+    """Print and return the full simulation database table."""
     df = pd.read_csv(fn_csv, index_col=0)
     print(df)
     return df
 
-def search_sim_db(fn_csv, col_condition):
-    """Use 'column == column' to filter out NaN values."""
+
+def search_sim_db(fn_csv: str, col_condition: str) -> pd.Index:
+    """Return case IDs matching a pandas query expression.
+
+    Use expressions such as ``status == 'DONE'`` or ``status == status``
+    to filter out NaN rows.
+    """
     df = pd.read_csv(fn_csv, index_col=0)
     df_sel = df.query(col_condition)
     return df_sel.index
 
-def simple_usage():
+
+def simple_usage() -> None:
+    """Run a minimal end-to-end demonstration of the CRUD APIs."""
     sim_db = dict(
-        sim_a = {'date_create': 20240101, 'directory': 'd_sim_a', 'exec_bin': 'prog_a','input_files': ['f1', 'f2'], 'status':'DONE'},
-        sim_b = {'date_create': 20240201, 'directory': 'd_sim_a/b', 'exec_bin': 'prog_b','input_files': ['f5'], 'status':'RUNNING'},
+        sim_a = {'date_create': 20240101, 'directory': 'd_sim_a', 'exec_bin': 'prog_a', 'input_files': ['f1', 'f2'], 'status':'DONE'},
+        sim_b = {'date_create': 20240201, 'directory': 'd_sim_a/b', 'exec_bin': 'prog_b', 'input_files': ['f5'], 'status':'RUNNING'},
         sim_c = {'date_create': 20240321, 'directory': 'd_sim_a/c/d', 'exec_bin': 'prog_c','input_files': ['f3', 'f4']},
     )
     fn_csv = 'test.csv'


### PR DESCRIPTION
### Motivation
- Improve code clarity and maintainability by adding type hints and short docstrings to the simple CSV-backed CRUD utilities.
- Make function intents and return shapes explicit to aid static checking and downstream usage.

### Description
- Imported `Any` and `Mapping` from `typing` and added type annotations to public functions such as `create_csv_db`, `add_cases`, `add_case_info`, `upd_cases`, `del_cases`, `list_case_info`, `list_sim_db`, and `search_sim_db`.
- Added concise docstrings for each function describing purpose and parameter/return behavior, and refined `search_sim_db` docstring to show example query usage.
- Specified return types for listing functions (`pd.DataFrame`) and `search_sim_db` (`pd.Index`), and updated `del_cases` to use `list[str]` for the case id list parameter.
- Minor formatting/whitespace adjustments and a clarified `simple_usage` docstring with preserved demonstration of the CRUD flow.

### Testing
- Executed the module demonstration via `python sim_db.py` which calls `simple_usage()` to exercise `create_csv_db`, `add_cases`, `del_cases`, `upd_cases`, `add_case_info`, `list_case_info`, `search_sim_db`, and `list_sim_db`, and the script ran without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d130873f7883288bbc59de552b0f52)