### PR TITLE
Add REST-based central sim DB workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,14 +152,21 @@ Security defaults:
   - `--allowed-db-path /exact/path.csv`
   - `--allowed-base-dir /safe/base/dir`
 
-Start server (local host):
+Start server (local host, Linux/macOS):
 
 ```bash
 export SIM_DB_API_TOKEN='replace-me'
 python sim_db_server.py --host 127.0.0.1 --port 8765 --db ~/sim_db.csv
 ```
 
-Client examples:
+Start server (Windows PowerShell):
+
+```powershell
+$env:SIM_DB_API_TOKEN = 'replace-me'
+python .\sim_db_server.py --host 127.0.0.1 --port 8765 --db $HOME\sim_db.csv
+```
+
+Client examples (Linux/macOS):
 
 ```bash
 export SIM_DB_API_TOKEN='replace-me'
@@ -170,6 +177,24 @@ python sim_db_client.py --url http://127.0.0.1:8765 add \
 python sim_db_client.py --url http://127.0.0.1:8765 done --case c100
 python sim_db_client.py --url http://127.0.0.1:8765 list
 ```
+
+Client examples (Windows PowerShell):
+
+```powershell
+$env:SIM_DB_API_TOKEN = 'replace-me'
+python .\sim_db_client.py --url http://127.0.0.1:8765 health
+python .\sim_db_client.py --url http://127.0.0.1:8765 init
+python .\sim_db_client.py --url http://127.0.0.1:8765 add `
+  --case c100 --inp c100.inp --bin solver --status start --work-dir C:\work\c100
+python .\sim_db_client.py --url http://127.0.0.1:8765 done --case c100
+python .\sim_db_client.py --url http://127.0.0.1:8765 list
+```
+
+Windows notes:
+
+- Server/client code now uses `pathlib.Path.resolve()` for path normalization and allowlist checks, so Windows drive-letter paths are handled more safely than plain string-prefix checks.
+- If the server runs on a different Windows machine, bind to a reachable host/IP and open the firewall only for trusted sources.
+- Keep the Bearer token in an environment variable rather than hardcoding it into scripts.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Useful for tracking simulation runs from submit scripts with a simple CLI.
 
 - Python 3
 
-## Revised behavior (v1.3)
+## Revised behavior (v1.4)
 
 - CSV DB tracks `work_dir` as a first-class field.
 - Added `state_changed_at` timestamp (ISO date+time, local time) that updates:
@@ -14,13 +14,16 @@ Useful for tracking simulation runs from submit scripts with a simple CLI.
   - when status changes via `done`
 - Existing `created_at`/`updated_at` remain for compatibility.
 - CSV column order is now stable and script-friendly:
-  - `case, work_dir, bin, inp, input_files, status, note, notes, state_changed_at, created_at, updated_at`
+  - `case, work_dir, bin, inp, input_files, extra_params, status, note, notes, state_changed_at, created_at, updated_at`
 - CLI supports both:
   - quick single-input usage via `--inp file.inp`
   - repeatable multi-input usage via `--input-file fileA --input-file fileB`
 - `--inp` and `--input-file` can be used together. Stored fields:
   - `inp`: primary input (first one)
   - `input_files`: all inputs joined as `;`
+- Extra runtime keyword parameters are supported (useful for parameter-driven runs without dedicated input files):
+  - `--extra-param key=value` (repeatable, stored as JSON text)
+  - `--extra-params '{"threads":8,"mode":"fast"}'` (store a raw params string)
 - Optional short note field is supported via `--note` (legacy alias `--notes`).
 - Status validation remains strict: only `start|restart|done`.
 - Default DB path remains `~/sim_db.csv`.
@@ -77,6 +80,8 @@ python sim_db.py add \
   --work-dir ./runs/case_003 \
   --inp model_003.inp \
   --input-file bc_003.inp \
+  --extra-param threads=16 \
+  --extra-param precision=double \
   --bin solver_v2 \
   --status restart \
   --note "resubmission after mesh fix" \
@@ -196,7 +201,8 @@ export SIM_DB_API_TOKEN='replace-me'
 python sim_db_client.py --url http://127.0.0.1:8765 health
 python sim_db_client.py --url http://127.0.0.1:8765 init
 python sim_db_client.py --url http://127.0.0.1:8765 create \
-  --case c100 --inp c100.inp --bin solver --status start --work-dir /work/c100
+  --case c100 --inp c100.inp --bin solver --status start --work-dir /work/c100 \
+  --extra-params '{"threads":8,"precision":"double"}'
 python sim_db_client.py --url http://127.0.0.1:8765 read --case c100
 python sim_db_client.py --url http://127.0.0.1:8765 update --case c100 --field status=restart --field note='retry'
 python sim_db_client.py --url http://127.0.0.1:8765 done --case c100
@@ -211,7 +217,8 @@ $env:SIM_DB_API_TOKEN = 'replace-me'
 python .\sim_db_client.py --url http://127.0.0.1:8765 health
 python .\sim_db_client.py --url http://127.0.0.1:8765 init
 python .\sim_db_client.py --url http://127.0.0.1:8765 create `
-  --case c100 --inp c100.inp --bin solver --status start --work-dir C:\work\c100
+  --case c100 --inp c100.inp --bin solver --status start --work-dir C:\work\c100 `
+  --extra-params '{"threads":8,"precision":"double"}'
 python .\sim_db_client.py --url http://127.0.0.1:8765 read --case c100
 python .\sim_db_client.py --url http://127.0.0.1:8765 update --case c100 --field status=restart --field note='retry'
 python .\sim_db_client.py --url http://127.0.0.1:8765 done --case c100

--- a/README.md
+++ b/README.md
@@ -1,252 +1,60 @@
-A tiny simulation CSV database utility.
+# mini_sim_db
 
-Useful for tracking simulation runs from submit scripts with a simple CLI.
+Tiny CSV-backed simulation run tracker.
+
+Use it either:
+- locally via CLI (`sim_db.py`), or
+- over REST (`sim_db_server.py` + `sim_db_client.py`) when you want a central DB host.
+
+For full design notes, schema details, remote workflow, and examples, see **`tutorial.ipynb`**.
 
 ## Requirements
 
 - Python 3
 
-## Revised behavior (v1.4)
-
-- CSV DB tracks `work_dir` as a first-class field.
-- Added `state_changed_at` timestamp (ISO date+time, local time) that updates:
-  - when a case is added
-  - when status changes via `done`
-- Existing `created_at`/`updated_at` remain for compatibility.
-- CSV column order is now stable and script-friendly:
-  - `case, work_dir, bin, inp, input_files, extra_params, status, note, notes, state_changed_at, created_at, updated_at`
-- CLI supports both:
-  - quick single-input usage via `--inp file.inp`
-  - repeatable multi-input usage via `--input-file fileA --input-file fileB`
-- `--inp` and `--input-file` can be used together. Stored fields:
-  - `inp`: primary input (first one)
-  - `input_files`: all inputs joined as `;`
-- Extra runtime keyword parameters are supported (useful for parameter-driven runs without dedicated input files):
-  - `--extra-param key=value` (repeatable, stored as JSON text)
-  - `--extra-params '{"threads":8,"mode":"fast"}'` (store a raw params string)
-- Optional short note field is supported via `--note` (legacy alias `--notes`).
-- Status validation remains strict: only `start|restart|done`.
-- Default DB path remains `~/sim_db.csv`.
-- CRUD-style helper functions remain available in `sim_db.py` (`create_csv_db`, `add_cases`, `upd_cases`, `del_cases`, etc.).
-
-## CLI
-
-Default DB file: `~/sim_db.csv`
+## Quick start (local CLI)
 
 ```bash
-# initialize the default DB
+# initialize DB (default: ~/sim_db.csv)
 python sim_db.py init
 
-# use a custom DB file
-python sim_db.py init --db /path/to/my_sim_db.csv
-```
-
-### Add a simulation item
-
-Allowed status values are strictly:
-
-- `start`
-- `restart`
-- `done`
-
-Single-input convenience:
-
-```bash
+# add one case
 python sim_db.py add \
   --case case_001 \
-  --work-dir "$PWD" \
-  --inp model_001.inp \
-  --bin solver_v2 \
+  --inp case_001.inp \
+  --bin solver \
   --status start
-```
 
-Multi-input (repeatable) usage:
-
-```bash
-python sim_db.py add \
-  --case case_002 \
-  --work-dir /scratch/project/case_002 \
-  --input-file model_002.inp \
-  --input-file mesh_002.inp \
-  --bin solver_v2 \
-  --status restart
-```
-
-With optional note and custom DB path:
-
-```bash
-python sim_db.py add \
-  --case case_003 \
-  --work-dir ./runs/case_003 \
-  --inp model_003.inp \
-  --input-file bc_003.inp \
-  --extra-param threads=16 \
-  --extra-param precision=double \
-  --bin solver_v2 \
-  --status restart \
-  --note "resubmission after mesh fix" \
-  --db ./sim_db.csv
-```
-
-If `--work-dir` is not provided, the CLI stores the current working directory.
-
-### Mark a case as done
-
-```bash
+# mark case done
 python sim_db.py done --case case_001
-```
 
-This updates both `status=done` and `state_changed_at`.
-
-### List DB content
-
-```bash
+# list all records
 python sim_db.py list
 ```
 
-## Submit-script integration examples
+Notes:
+- allowed status values: `start`, `restart`, `done`
+- if `--work-dir` is omitted, current working directory is stored
 
-Before pre-processing / submit:
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-CASE="case_123"
-INP="${CASE}.inp"
-BIN="solver_main"
-DB="${DB:-$HOME/sim_db.csv}"
-
-python /path/to/mini_sim_db/sim_db.py init --db "$DB"
-python /path/to/mini_sim_db/sim_db.py add \
-  --case "$CASE" \
-  --work-dir "$PWD" \
-  --inp "$INP" \
-  --bin "$BIN" \
-  --status start \
-  --db "$DB"
-
-# preproc and submit
-./preproc "$INP"
-./submit "$CASE"
-```
-
-After post-processing:
+## Quick start (REST)
 
 ```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-CASE="case_123"
-DB="${DB:-$HOME/sim_db.csv}"
-python /path/to/mini_sim_db/sim_db.py done --case "$CASE" --db "$DB"
-```
-
-## REST host + client (centralized writes + local durability)
-
-Modules:
-
-- `sim_db_server.py` — stdlib HTTP JSON API host
-- `sim_db_client.py` — stdlib client + CLI with dual-write fallback
-
-Design notes:
-
-- REST layer reuses existing `sim_db.py` helpers (`init_sim_db`, `add_sim_item`, `upd_cases`, `del_cases`, `list_items`, `mark_done`) instead of duplicating CSV logic.
-- `run_host` is auto-populated by client mutating operations (`create`, `update`, `done`, `delete`) using local hostname and stored as a DB column.
-- Mutating client operations are **dual-write** by default:
-  1. write to local durable mirror DB (default: `~/.sim_db_client_local.csv`)
-  2. try remote write
-  3. if remote is down, command still succeeds with `fallback: local-only`
-
-Security defaults:
-
-- Bearer token is mandatory (`--token` or `SIM_DB_API_TOKEN`)
-- If no allowlist is configured, server only allows writes to the configured default DB path
-- Optional write scope controls:
-  - `--allowed-db-path /exact/path.csv`
-  - `--allowed-base-dir /safe/base/dir`
-
-### REST CRUD API
-
-- `POST /cases` → create
-- `GET /cases` → read all
-- `GET /cases/<case>` → read one
-- `PATCH /cases/<case>` → update selected fields
-- `DELETE /cases/<case>` → delete
-
-Compatibility routes still exist: `/add`, `/done`, `/update`, `/delete`, `/init`.
-
-### Start server
-
-Linux/macOS:
-
-```bash
+# terminal 1: start server
 export SIM_DB_API_TOKEN='replace-me'
 python sim_db_server.py --host 127.0.0.1 --port 8765 --db ~/sim_db.csv
-```
 
-Windows PowerShell:
-
-```powershell
-$env:SIM_DB_API_TOKEN = 'replace-me'
-python .\sim_db_server.py --host 127.0.0.1 --port 8765 --db $HOME\sim_db.csv
-```
-
-### Client usage (CRUD)
-
-Linux/macOS:
-
-```bash
+# terminal 2: use client
 export SIM_DB_API_TOKEN='replace-me'
 python sim_db_client.py --url http://127.0.0.1:8765 health
 python sim_db_client.py --url http://127.0.0.1:8765 init
 python sim_db_client.py --url http://127.0.0.1:8765 create \
-  --case c100 --inp c100.inp --bin solver --status start --work-dir /work/c100 \
-  --extra-params '{"threads":8,"precision":"double"}'
-python sim_db_client.py --url http://127.0.0.1:8765 read --case c100
-python sim_db_client.py --url http://127.0.0.1:8765 update --case c100 --field status=restart --field note='retry'
+  --case c100 --inp c100.inp --bin solver --status start
 python sim_db_client.py --url http://127.0.0.1:8765 done --case c100
-python sim_db_client.py --url http://127.0.0.1:8765 delete --case c100
 python sim_db_client.py --url http://127.0.0.1:8765 list
 ```
-
-Windows PowerShell:
-
-```powershell
-$env:SIM_DB_API_TOKEN = 'replace-me'
-python .\sim_db_client.py --url http://127.0.0.1:8765 health
-python .\sim_db_client.py --url http://127.0.0.1:8765 init
-python .\sim_db_client.py --url http://127.0.0.1:8765 create `
-  --case c100 --inp c100.inp --bin solver --status start --work-dir C:\work\c100 `
-  --extra-params '{"threads":8,"precision":"double"}'
-python .\sim_db_client.py --url http://127.0.0.1:8765 read --case c100
-python .\sim_db_client.py --url http://127.0.0.1:8765 update --case c100 --field status=restart --field note='retry'
-python .\sim_db_client.py --url http://127.0.0.1:8765 done --case c100
-python .\sim_db_client.py --url http://127.0.0.1:8765 delete --case c100
-python .\sim_db_client.py --url http://127.0.0.1:8765 list
-```
-
-Dual-write options:
-
-- default local mirror DB: `~/.sim_db_client_local.csv`
-- override: `--local-db /path/to/local.csv`
-- disable local write: `--no-local-write`
-
-Windows notes:
-
-- Path safety uses `pathlib.Path.resolve()` for allowlist checks.
-- If server runs remotely, bind host/IP intentionally and restrict firewall rules.
-- Keep token in environment variables instead of hardcoding in scripts.
 
 ## Tests
 
 ```bash
 python -m unittest -v
 ```
-
-## CI/CD
-
-This repository includes a GitHub Actions pipeline at `.github/workflows/ci-cd.yml`:
-
-- **CI**: Runs unit tests (`python -m unittest -v`) on Python 3.10, 3.11, and 3.12 for every push and pull request.
-- **CD**: On pushes to `main`, creates and uploads a source tarball artifact.

--- a/README.md
+++ b/README.md
@@ -137,12 +137,21 @@ DB="${DB:-$HOME/sim_db.csv}"
 python /path/to/mini_sim_db/sim_db.py done --case "$CASE" --db "$DB"
 ```
 
-## REST host + client (centralized writes)
+## REST host + client (centralized writes + local durability)
 
-New modules (without touching `sim_db.py`):
+Modules:
 
-- `sim_db_server.py` — tiny stdlib HTTP JSON server
-- `sim_db_client.py` — tiny stdlib client + CLI
+- `sim_db_server.py` — stdlib HTTP JSON API host
+- `sim_db_client.py` — stdlib client + CLI with dual-write fallback
+
+Design notes:
+
+- REST layer reuses existing `sim_db.py` helpers (`init_sim_db`, `add_sim_item`, `upd_cases`, `del_cases`, `list_items`, `mark_done`) instead of duplicating CSV logic.
+- `run_host` is auto-populated by client mutating operations (`create`, `update`, `done`, `delete`) using local hostname and stored as a DB column.
+- Mutating client operations are **dual-write** by default:
+  1. write to local durable mirror DB (default: `~/.sim_db_client_local.csv`)
+  2. try remote write
+  3. if remote is down, command still succeeds with `fallback: local-only`
 
 Security defaults:
 
@@ -152,49 +161,75 @@ Security defaults:
   - `--allowed-db-path /exact/path.csv`
   - `--allowed-base-dir /safe/base/dir`
 
-Start server (local host, Linux/macOS):
+### REST CRUD API
+
+- `POST /cases` → create
+- `GET /cases` → read all
+- `GET /cases/<case>` → read one
+- `PATCH /cases/<case>` → update selected fields
+- `DELETE /cases/<case>` → delete
+
+Compatibility routes still exist: `/add`, `/done`, `/update`, `/delete`, `/init`.
+
+### Start server
+
+Linux/macOS:
 
 ```bash
 export SIM_DB_API_TOKEN='replace-me'
 python sim_db_server.py --host 127.0.0.1 --port 8765 --db ~/sim_db.csv
 ```
 
-Start server (Windows PowerShell):
+Windows PowerShell:
 
 ```powershell
 $env:SIM_DB_API_TOKEN = 'replace-me'
 python .\sim_db_server.py --host 127.0.0.1 --port 8765 --db $HOME\sim_db.csv
 ```
 
-Client examples (Linux/macOS):
+### Client usage (CRUD)
+
+Linux/macOS:
 
 ```bash
 export SIM_DB_API_TOKEN='replace-me'
 python sim_db_client.py --url http://127.0.0.1:8765 health
 python sim_db_client.py --url http://127.0.0.1:8765 init
-python sim_db_client.py --url http://127.0.0.1:8765 add \
+python sim_db_client.py --url http://127.0.0.1:8765 create \
   --case c100 --inp c100.inp --bin solver --status start --work-dir /work/c100
+python sim_db_client.py --url http://127.0.0.1:8765 read --case c100
+python sim_db_client.py --url http://127.0.0.1:8765 update --case c100 --field status=restart --field note='retry'
 python sim_db_client.py --url http://127.0.0.1:8765 done --case c100
+python sim_db_client.py --url http://127.0.0.1:8765 delete --case c100
 python sim_db_client.py --url http://127.0.0.1:8765 list
 ```
 
-Client examples (Windows PowerShell):
+Windows PowerShell:
 
 ```powershell
 $env:SIM_DB_API_TOKEN = 'replace-me'
 python .\sim_db_client.py --url http://127.0.0.1:8765 health
 python .\sim_db_client.py --url http://127.0.0.1:8765 init
-python .\sim_db_client.py --url http://127.0.0.1:8765 add `
+python .\sim_db_client.py --url http://127.0.0.1:8765 create `
   --case c100 --inp c100.inp --bin solver --status start --work-dir C:\work\c100
+python .\sim_db_client.py --url http://127.0.0.1:8765 read --case c100
+python .\sim_db_client.py --url http://127.0.0.1:8765 update --case c100 --field status=restart --field note='retry'
 python .\sim_db_client.py --url http://127.0.0.1:8765 done --case c100
+python .\sim_db_client.py --url http://127.0.0.1:8765 delete --case c100
 python .\sim_db_client.py --url http://127.0.0.1:8765 list
 ```
 
+Dual-write options:
+
+- default local mirror DB: `~/.sim_db_client_local.csv`
+- override: `--local-db /path/to/local.csv`
+- disable local write: `--no-local-write`
+
 Windows notes:
 
-- Server/client code now uses `pathlib.Path.resolve()` for path normalization and allowlist checks, so Windows drive-letter paths are handled more safely than plain string-prefix checks.
-- If the server runs on a different Windows machine, bind to a reachable host/IP and open the firewall only for trusted sources.
-- Keep the Bearer token in an environment variable rather than hardcoding it into scripts.
+- Path safety uses `pathlib.Path.resolve()` for allowlist checks.
+- If server runs remotely, bind host/IP intentionally and restrict firewall rules.
+- Keep token in environment variables instead of hardcoding in scripts.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,40 @@ DB="${DB:-$HOME/sim_db.csv}"
 python /path/to/mini_sim_db/sim_db.py done --case "$CASE" --db "$DB"
 ```
 
+## REST host + client (centralized writes)
+
+New modules (without touching `sim_db.py`):
+
+- `sim_db_server.py` — tiny stdlib HTTP JSON server
+- `sim_db_client.py` — tiny stdlib client + CLI
+
+Security defaults:
+
+- Bearer token is mandatory (`--token` or `SIM_DB_API_TOKEN`)
+- If no allowlist is configured, server only allows writes to the configured default DB path
+- Optional write scope controls:
+  - `--allowed-db-path /exact/path.csv`
+  - `--allowed-base-dir /safe/base/dir`
+
+Start server (local host):
+
+```bash
+export SIM_DB_API_TOKEN='replace-me'
+python sim_db_server.py --host 127.0.0.1 --port 8765 --db ~/sim_db.csv
+```
+
+Client examples:
+
+```bash
+export SIM_DB_API_TOKEN='replace-me'
+python sim_db_client.py --url http://127.0.0.1:8765 health
+python sim_db_client.py --url http://127.0.0.1:8765 init
+python sim_db_client.py --url http://127.0.0.1:8765 add \
+  --case c100 --inp c100.inp --bin solver --status start --work-dir /work/c100
+python sim_db_client.py --url http://127.0.0.1:8765 done --case c100
+python sim_db_client.py --url http://127.0.0.1:8765 list
+```
+
 ## Tests
 
 ```bash

--- a/sim_db.py
+++ b/sim_db.py
@@ -3,13 +3,14 @@ simple database for simulations and more (CSV-backed CRUD)
 
 author: hyharry@github
 license: MIT License
-version: 1.3
+version: 1.4
 """
 
 __doc__ = 'simple database for simulations and more (CSV-backed CRUD)'
 
 import argparse
 import csv
+import json
 import os
 import re
 import sys
@@ -23,6 +24,7 @@ CLI_FIELDS = [
     'bin',
     'inp',
     'input_files',
+    'extra_params',
     'status',
     'note',
     'notes',
@@ -107,6 +109,29 @@ def _normalize_input_files(inp: str | None, input_files: list[str] | None) -> tu
         raise ValueError("At least one input file is required (use --inp and/or --input-file)")
 
     return files[0], files
+
+
+def _normalize_extra_params(extra_params: str | None, extra_param_pairs: list[str] | None) -> str:
+    if extra_params and extra_param_pairs:
+        raise ValueError("Use either --extra-params or --extra-param, not both")
+
+    if extra_params is not None:
+        return str(extra_params)
+
+    out: dict[str, str] = {}
+    for pair in extra_param_pairs or []:
+        if "=" not in pair:
+            raise ValueError(f"Invalid --extra-param '{pair}', expected key=value")
+        key, value = pair.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"Invalid --extra-param '{pair}', empty key")
+        out[key] = value
+
+    if not out:
+        return ''
+
+    return json.dumps(out, sort_keys=True, ensure_ascii=False)
 
 
 def create_csv_db(fn_csv: str, dic: Mapping[str, Mapping[str, Any]]) -> None:
@@ -286,6 +311,7 @@ def add_sim_item(
     input_files: list[str] | None = None,
     note: str | None = None,
     work_dir: str | None = None,
+    extra_params: str | None = None,
 ) -> None:
     """Add one simulation item to the DB."""
     _validate_status(status)
@@ -310,6 +336,7 @@ def add_sim_item(
             'bin': bin_name,
             'inp': primary_inp,
             'input_files': _serialize_input_files(files),
+            'extra_params': str(extra_params or ''),
             'status': status,
             'note': note_value,
             'notes': note_value,
@@ -369,6 +396,8 @@ def _build_cli() -> argparse.ArgumentParser:
     p_add.add_argument('--input-file', action='append', default=[], help='Input file (repeatable)')
     p_add.add_argument('--bin', dest='bin_name', required=True, help='Executable / binary name')
     p_add.add_argument('--work-dir', '--wd', dest='work_dir', default=None, help='Working directory for this case (default: current dir)')
+    p_add.add_argument('--extra-param', action='append', default=[], help='Extra runtime parameter key=value (repeatable)')
+    p_add.add_argument('--extra-params', default=None, help='Raw extra runtime parameters string (for example JSON)')
     p_add.add_argument('--status', required=True, help='start|restart|done')
     p_add.add_argument('--note', default='', help='Optional short note/documentation text')
     p_add.add_argument('--notes', dest='note', help='Backward-compatible alias of --note')
@@ -401,6 +430,7 @@ def main(argv: list[str] | None = None) -> int:
                 db_path=args.db,
                 note=args.note,
                 work_dir=args.work_dir,
+                extra_params=_normalize_extra_params(args.extra_params, args.extra_param),
             )
         elif args.command == 'done':
             mark_done(case=args.case, db_path=args.db)

--- a/sim_db_client.py
+++ b/sim_db_client.py
@@ -10,6 +10,18 @@ import sys
 from typing import Any
 from urllib import error, parse, request
 
+
+class RemoteRequestError(RuntimeError):
+    """Base error for remote request failures."""
+
+
+class RemoteTransportError(RemoteRequestError):
+    """Network/transport failure reaching remote server."""
+
+
+class RemoteResponseError(RemoteRequestError):
+    """Remote server responded with an HTTP/application error."""
+
 from sim_db import add_sim_item, del_cases, init_sim_db, mark_done, upd_cases
 
 
@@ -75,7 +87,7 @@ class SimDbClient:
         return self.create(**kwargs)
 
     def read(self, *, case: str, db_path: str | None = None) -> dict[str, Any]:
-        path = f"/cases/{parse.quote(case)}"
+        path = f"/cases/{parse.quote(case, safe='')}"
         if db_path:
             path += "?" + parse.urlencode({"db_path": db_path})
         return self._request("GET", path)
@@ -139,7 +151,7 @@ class SimDbClient:
             if local_error:
                 out["local_error"] = local_error
             return out
-        except RuntimeError as exc:
+        except RemoteTransportError as exc:
             if local_ok:
                 return {
                     "ok": True,
@@ -194,11 +206,11 @@ class SimDbClient:
         if op == "create":
             return self._request("POST", "/cases", payload)
         if op == "update":
-            case = parse.quote(payload["case"])
+            case = parse.quote(payload["case"], safe='')
             remote_payload = {k: v for k, v in payload.items() if k != "case"}
             return self._request("PATCH", f"/cases/{case}", remote_payload)
         if op == "delete":
-            case = parse.quote(payload["case"])
+            case = parse.quote(payload["case"], safe='')
             db_path = payload.get("db_path")
             path = f"/cases/{case}"
             if db_path:
@@ -221,9 +233,9 @@ class SimDbClient:
         except error.HTTPError as exc:
             body = exc.read().decode("utf-8")
             msg = body or str(exc)
-            raise RuntimeError(f"HTTP {exc.code}: {msg}") from exc
-        except error.URLError as exc:
-            raise RuntimeError(f"request failed: {exc}") from exc
+            raise RemoteResponseError(f"HTTP {exc.code}: {msg}") from exc
+        except (error.URLError, TimeoutError) as exc:
+            raise RemoteTransportError(f"request failed: {exc}") from exc
 
 
 def _parse_fields(pairs: list[str] | None) -> dict[str, str]:

--- a/sim_db_client.py
+++ b/sim_db_client.py
@@ -1,20 +1,32 @@
-"""Tiny REST client for mini_sim_db server."""
+"""Tiny REST client for mini_sim_db server with local durable dual-write."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import os
+import socket
 import sys
 from typing import Any
 from urllib import error, parse, request
 
+from sim_db import add_sim_item, del_cases, init_sim_db, mark_done, upd_cases
+
 
 class SimDbClient:
-    def __init__(self, base_url: str, token: str, timeout: float = 10.0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        token: str,
+        timeout: float = 10.0,
+        local_db_path: str | None = None,
+        enable_local_write: bool = True,
+    ) -> None:
         self.base_url = base_url.rstrip("/")
         self.token = token
         self.timeout = timeout
+        self.local_db_path = os.path.expanduser(local_db_path) if local_db_path else None
+        self.enable_local_write = enable_local_write
 
     def health(self) -> dict[str, Any]:
         return self._request("GET", "/health")
@@ -25,7 +37,7 @@ class SimDbClient:
             payload["db_path"] = db_path
         return self._request("POST", "/init", payload)
 
-    def add(
+    def create(
         self,
         *,
         case: str,
@@ -36,11 +48,13 @@ class SimDbClient:
         note: str | None = None,
         work_dir: str | None = None,
         db_path: str | None = None,
+        run_host: str | None = None,
     ) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "case": case,
             "bin_name": bin_name,
             "status": status,
+            "run_host": run_host or socket.gethostname(),
         }
         if inp is not None:
             payload["inp"] = inp
@@ -52,19 +66,141 @@ class SimDbClient:
             payload["work_dir"] = work_dir
         if db_path is not None:
             payload["db_path"] = db_path
-        return self._request("POST", "/add", payload)
+        return self._dual_write("create", payload)
 
-    def done(self, *, case: str, db_path: str | None = None) -> dict[str, Any]:
-        payload: dict[str, Any] = {"case": case}
+    def add(self, **kwargs: Any) -> dict[str, Any]:
+        return self.create(**kwargs)
+
+    def read(self, *, case: str, db_path: str | None = None) -> dict[str, Any]:
+        path = f"/cases/{parse.quote(case)}"
+        if db_path:
+            path += "?" + parse.urlencode({"db_path": db_path})
+        return self._request("GET", path)
+
+    def done(self, *, case: str, db_path: str | None = None, run_host: str | None = None) -> dict[str, Any]:
+        return self.update(
+            case=case,
+            fields={"status": "done"},
+            db_path=db_path,
+            run_host=run_host,
+        )
+
+    def update(
+        self,
+        *,
+        case: str,
+        fields: dict[str, Any],
+        db_path: str | None = None,
+        run_host: str | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "case": case,
+            "fields": fields,
+            "run_host": run_host or socket.gethostname(),
+        }
         if db_path is not None:
             payload["db_path"] = db_path
-        return self._request("POST", "/done", payload)
+        return self._dual_write("update", payload)
+
+    def delete(self, *, case: str, db_path: str | None = None, run_host: str | None = None) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "case": case,
+            "run_host": run_host or socket.gethostname(),
+        }
+        if db_path is not None:
+            payload["db_path"] = db_path
+        return self._dual_write("delete", payload)
 
     def list(self, db_path: str | None = None) -> dict[str, Any]:
         path = "/cases"
         if db_path:
             path += "?" + parse.urlencode({"db_path": db_path})
         return self._request("GET", path)
+
+    def _dual_write(self, op: str, payload: dict[str, Any]) -> dict[str, Any]:
+        local_ok = None
+        local_error = None
+        if self.enable_local_write and self.local_db_path:
+            try:
+                self._apply_local(op, payload)
+                local_ok = True
+            except Exception as exc:
+                local_ok = False
+                local_error = str(exc)
+
+        try:
+            remote = self._request_for_op(op, payload)
+            out = {"ok": True, "remote_ok": True, "remote": remote}
+            if local_ok is not None:
+                out["local_ok"] = local_ok
+            if local_error:
+                out["local_error"] = local_error
+            return out
+        except RuntimeError as exc:
+            if local_ok:
+                return {
+                    "ok": True,
+                    "remote_ok": False,
+                    "remote_error": str(exc),
+                    "local_ok": True,
+                    "fallback": "local-only",
+                }
+            raise
+
+    def _apply_local(self, op: str, payload: dict[str, Any]) -> None:
+        assert self.local_db_path is not None
+        init_sim_db(self.local_db_path)
+        case = payload["case"]
+        run_host = payload.get("run_host")
+
+        if op == "create":
+            add_sim_item(
+                case=case,
+                inp=payload.get("inp"),
+                input_files=payload.get("input_files"),
+                bin_name=payload["bin_name"],
+                status=payload["status"],
+                db_path=self.local_db_path,
+                note=payload.get("note"),
+                work_dir=payload.get("work_dir"),
+            )
+            if run_host:
+                upd_cases(self.local_db_path, {case: {"run_host": str(run_host)}})
+            return
+
+        if op == "update":
+            fields = dict(payload.get("fields") or {})
+            if run_host:
+                fields["run_host"] = str(run_host)
+            if fields.get("status") == "done":
+                mark_done(case=case, db_path=self.local_db_path)
+                fields.pop("status", None)
+                fields.pop("state_changed_at", None)
+            if fields:
+                upd_cases(self.local_db_path, {case: fields})
+            return
+
+        if op == "delete":
+            del_cases(self.local_db_path, [case])
+            return
+
+        raise ValueError(f"unsupported op: {op}")
+
+    def _request_for_op(self, op: str, payload: dict[str, Any]) -> dict[str, Any]:
+        if op == "create":
+            return self._request("POST", "/cases", payload)
+        if op == "update":
+            case = parse.quote(payload["case"])
+            remote_payload = {k: v for k, v in payload.items() if k != "case"}
+            return self._request("PATCH", f"/cases/{case}", remote_payload)
+        if op == "delete":
+            case = parse.quote(payload["case"])
+            db_path = payload.get("db_path")
+            path = f"/cases/{case}"
+            if db_path:
+                path += "?" + parse.urlencode({"db_path": db_path})
+            return self._request("DELETE", path)
+        raise ValueError(f"unsupported op: {op}")
 
     def _request(self, method: str, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
         data = None
@@ -86,30 +222,69 @@ class SimDbClient:
             raise RuntimeError(f"request failed: {exc}") from exc
 
 
+def _parse_fields(pairs: list[str] | None) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for pair in pairs or []:
+        if "=" not in pair:
+            raise ValueError(f"invalid --field '{pair}', expected key=value")
+        key, value = pair.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"invalid --field '{pair}', empty key")
+        fields[key] = value
+    return fields
+
+
+def _add_create_like_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--case", required=True)
+    parser.add_argument("--bin", dest="bin_name", required=True)
+    parser.add_argument("--status", required=True)
+    parser.add_argument("--inp", default=None)
+    parser.add_argument("--input-file", action="append", default=None)
+    parser.add_argument("--note", default=None)
+    parser.add_argument("--work-dir", default=None)
+    parser.add_argument("--db", default=None)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description="mini_sim_db REST client")
     p.add_argument("--url", default="http://127.0.0.1:8765", help="Server base URL")
     p.add_argument("--token", default=None, help="Bearer token (or SIM_DB_API_TOKEN)")
+    p.add_argument(
+        "--local-db",
+        default=os.path.expanduser("~/.sim_db_client_local.csv"),
+        help="Local durable mirror DB for dual-write fallback (default: ~/.sim_db_client_local.csv)",
+    )
+    p.add_argument("--no-local-write", action="store_true", help="Disable local dual-write fallback")
     sub = p.add_subparsers(dest="cmd", required=True)
 
     sub.add_parser("health")
 
     p_init = sub.add_parser("init")
-    p_init.add_argument("--db", default=None, help="Optional db_path override")
+    p_init.add_argument("--db", default=None, help="Optional remote db_path override")
+
+    p_create = sub.add_parser("create")
+    _add_create_like_args(p_create)
 
     p_add = sub.add_parser("add")
-    p_add.add_argument("--case", required=True)
-    p_add.add_argument("--bin", dest="bin_name", required=True)
-    p_add.add_argument("--status", required=True)
-    p_add.add_argument("--inp", default=None)
-    p_add.add_argument("--input-file", action="append", default=None)
-    p_add.add_argument("--note", default=None)
-    p_add.add_argument("--work-dir", default=None)
-    p_add.add_argument("--db", default=None)
+    _add_create_like_args(p_add)
+
+    p_read = sub.add_parser("read")
+    p_read.add_argument("--case", required=True)
+    p_read.add_argument("--db", default=None)
+
+    p_update = sub.add_parser("update")
+    p_update.add_argument("--case", required=True)
+    p_update.add_argument("--field", action="append", default=None, help="key=value (repeatable)")
+    p_update.add_argument("--db", default=None)
 
     p_done = sub.add_parser("done")
     p_done.add_argument("--case", required=True)
     p_done.add_argument("--db", default=None)
+
+    p_delete = sub.add_parser("delete")
+    p_delete.add_argument("--case", required=True)
+    p_delete.add_argument("--db", default=None)
 
     p_list = sub.add_parser("list")
     p_list.add_argument("--db", default=None)
@@ -124,14 +299,20 @@ def main(argv: list[str] | None = None) -> int:
         print("Missing token. Set --token or SIM_DB_API_TOKEN", file=sys.stderr)
         return 2
 
-    client = SimDbClient(base_url=args.url, token=token)
+    client = SimDbClient(
+        base_url=args.url,
+        token=token,
+        local_db_path=None if args.no_local_write else args.local_db,
+        enable_local_write=not args.no_local_write,
+    )
+
     try:
         if args.cmd == "health":
             result = client.health()
         elif args.cmd == "init":
             result = client.init(db_path=args.db)
-        elif args.cmd == "add":
-            result = client.add(
+        elif args.cmd in {"create", "add"}:
+            result = client.create(
                 case=args.case,
                 inp=args.inp,
                 input_files=args.input_file,
@@ -141,13 +322,19 @@ def main(argv: list[str] | None = None) -> int:
                 work_dir=args.work_dir,
                 db_path=args.db,
             )
+        elif args.cmd == "read":
+            result = client.read(case=args.case, db_path=args.db)
+        elif args.cmd == "update":
+            result = client.update(case=args.case, fields=_parse_fields(args.field), db_path=args.db)
         elif args.cmd == "done":
             result = client.done(case=args.case, db_path=args.db)
+        elif args.cmd == "delete":
+            result = client.delete(case=args.case, db_path=args.db)
         elif args.cmd == "list":
             result = client.list(db_path=args.db)
         else:
             return 1
-    except RuntimeError as exc:
+    except (RuntimeError, ValueError) as exc:
         print(str(exc), file=sys.stderr)
         return 2
 

--- a/sim_db_client.py
+++ b/sim_db_client.py
@@ -47,6 +47,7 @@ class SimDbClient:
         input_files: list[str] | None = None,
         note: str | None = None,
         work_dir: str | None = None,
+        extra_params: str | None = None,
         db_path: str | None = None,
         run_host: str | None = None,
     ) -> dict[str, Any]:
@@ -64,6 +65,8 @@ class SimDbClient:
             payload["note"] = note
         if work_dir is not None:
             payload["work_dir"] = work_dir
+        if extra_params is not None:
+            payload["extra_params"] = extra_params
         if db_path is not None:
             payload["db_path"] = db_path
         return self._dual_write("create", payload)
@@ -163,6 +166,7 @@ class SimDbClient:
                 db_path=self.local_db_path,
                 note=payload.get("note"),
                 work_dir=payload.get("work_dir"),
+                extra_params=payload.get("extra_params"),
             )
             if run_host:
                 upd_cases(self.local_db_path, {case: {"run_host": str(run_host)}})
@@ -243,6 +247,7 @@ def _add_create_like_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--input-file", action="append", default=None)
     parser.add_argument("--note", default=None)
     parser.add_argument("--work-dir", default=None)
+    parser.add_argument("--extra-params", default=None, help="Raw extra runtime params string (for example JSON)")
     parser.add_argument("--db", default=None)
 
 
@@ -320,6 +325,7 @@ def main(argv: list[str] | None = None) -> int:
                 status=args.status,
                 note=args.note,
                 work_dir=args.work_dir,
+                extra_params=args.extra_params,
                 db_path=args.db,
             )
         elif args.cmd == "read":

--- a/sim_db_client.py
+++ b/sim_db_client.py
@@ -1,0 +1,159 @@
+"""Tiny REST client for mini_sim_db server."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+from urllib import error, parse, request
+
+
+class SimDbClient:
+    def __init__(self, base_url: str, token: str, timeout: float = 10.0) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.timeout = timeout
+
+    def health(self) -> dict[str, Any]:
+        return self._request("GET", "/health")
+
+    def init(self, db_path: str | None = None) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        if db_path:
+            payload["db_path"] = db_path
+        return self._request("POST", "/init", payload)
+
+    def add(
+        self,
+        *,
+        case: str,
+        bin_name: str,
+        status: str,
+        inp: str | None = None,
+        input_files: list[str] | None = None,
+        note: str | None = None,
+        work_dir: str | None = None,
+        db_path: str | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "case": case,
+            "bin_name": bin_name,
+            "status": status,
+        }
+        if inp is not None:
+            payload["inp"] = inp
+        if input_files is not None:
+            payload["input_files"] = input_files
+        if note is not None:
+            payload["note"] = note
+        if work_dir is not None:
+            payload["work_dir"] = work_dir
+        if db_path is not None:
+            payload["db_path"] = db_path
+        return self._request("POST", "/add", payload)
+
+    def done(self, *, case: str, db_path: str | None = None) -> dict[str, Any]:
+        payload: dict[str, Any] = {"case": case}
+        if db_path is not None:
+            payload["db_path"] = db_path
+        return self._request("POST", "/done", payload)
+
+    def list(self, db_path: str | None = None) -> dict[str, Any]:
+        path = "/cases"
+        if db_path:
+            path += "?" + parse.urlencode({"db_path": db_path})
+        return self._request("GET", path)
+
+    def _request(self, method: str, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        data = None
+        headers = {"Authorization": f"Bearer {self.token}"}
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        req = request.Request(self.base_url + path, method=method, headers=headers, data=data)
+        try:
+            with request.urlopen(req, timeout=self.timeout) as resp:
+                body = resp.read().decode("utf-8")
+                return json.loads(body) if body else {}
+        except error.HTTPError as exc:
+            body = exc.read().decode("utf-8")
+            msg = body or str(exc)
+            raise RuntimeError(f"HTTP {exc.code}: {msg}") from exc
+        except error.URLError as exc:
+            raise RuntimeError(f"request failed: {exc}") from exc
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="mini_sim_db REST client")
+    p.add_argument("--url", default="http://127.0.0.1:8765", help="Server base URL")
+    p.add_argument("--token", default=None, help="Bearer token (or SIM_DB_API_TOKEN)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("health")
+
+    p_init = sub.add_parser("init")
+    p_init.add_argument("--db", default=None, help="Optional db_path override")
+
+    p_add = sub.add_parser("add")
+    p_add.add_argument("--case", required=True)
+    p_add.add_argument("--bin", dest="bin_name", required=True)
+    p_add.add_argument("--status", required=True)
+    p_add.add_argument("--inp", default=None)
+    p_add.add_argument("--input-file", action="append", default=None)
+    p_add.add_argument("--note", default=None)
+    p_add.add_argument("--work-dir", default=None)
+    p_add.add_argument("--db", default=None)
+
+    p_done = sub.add_parser("done")
+    p_done.add_argument("--case", required=True)
+    p_done.add_argument("--db", default=None)
+
+    p_list = sub.add_parser("list")
+    p_list.add_argument("--db", default=None)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    token = args.token or os.getenv("SIM_DB_API_TOKEN")
+    if not token:
+        print("Missing token. Set --token or SIM_DB_API_TOKEN", file=sys.stderr)
+        return 2
+
+    client = SimDbClient(base_url=args.url, token=token)
+    try:
+        if args.cmd == "health":
+            result = client.health()
+        elif args.cmd == "init":
+            result = client.init(db_path=args.db)
+        elif args.cmd == "add":
+            result = client.add(
+                case=args.case,
+                inp=args.inp,
+                input_files=args.input_file,
+                bin_name=args.bin_name,
+                status=args.status,
+                note=args.note,
+                work_dir=args.work_dir,
+                db_path=args.db,
+            )
+        elif args.cmd == "done":
+            result = client.done(case=args.case, db_path=args.db)
+        elif args.cmd == "list":
+            result = client.list(db_path=args.db)
+        else:
+            return 1
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sim_db_server.py
+++ b/sim_db_server.py
@@ -1,0 +1,221 @@
+"""HTTP host for mini_sim_db.
+
+Small stdlib-only JSON API around sim_db.py for centralized case updates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+from sim_db import DEFAULT_DB_PATH, add_sim_item, init_sim_db, list_items, mark_done
+
+
+class SecurityPolicy:
+    """Validates API token and requested DB paths."""
+
+    def __init__(
+        self,
+        token: str,
+        default_db_path: str,
+        allowed_db_path: str | None = None,
+        allowed_base_dir: str | None = None,
+    ) -> None:
+        self.token = token
+        self.default_db_path = _norm(default_db_path)
+        self.allowed_db_path = _norm(allowed_db_path) if allowed_db_path else None
+        self.allowed_base_dir = _norm(allowed_base_dir) if allowed_base_dir else None
+
+    def is_authorized(self, auth_header: str | None) -> bool:
+        if not auth_header or not auth_header.startswith("Bearer "):
+            return False
+        return auth_header[len("Bearer ") :] == self.token
+
+    def resolve_db_path(self, requested_db_path: str | None) -> str:
+        if not requested_db_path:
+            return self.default_db_path
+
+        wanted = _norm(requested_db_path)
+
+        # safest default: only configured default DB path is writable
+        if self.allowed_db_path is None and self.allowed_base_dir is None:
+            if wanted == self.default_db_path:
+                return wanted
+            raise ValueError("db_path is not allowed")
+
+        if self.allowed_db_path and wanted == self.allowed_db_path:
+            return wanted
+
+        if self.allowed_base_dir and _is_within_base(wanted, self.allowed_base_dir):
+            return wanted
+
+        raise ValueError("db_path is outside allowed scope")
+
+
+class SimDbApiServer(ThreadingHTTPServer):
+    def __init__(self, server_address: tuple[str, int], policy: SecurityPolicy) -> None:
+        self.policy = policy
+        super().__init__(server_address, SimDbRequestHandler)
+
+
+class SimDbRequestHandler(BaseHTTPRequestHandler):
+    server: SimDbApiServer
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/health":
+            self._json(HTTPStatus.OK, {"ok": True})
+            return
+
+        if self.path.startswith("/cases"):
+            self._require_auth()
+            if not self._authorized:
+                return
+            query = self._query_dict()
+            db_path = query.get("db_path")
+            try:
+                resolved = self.server.policy.resolve_db_path(db_path)
+                data = list_items(resolved)
+            except Exception as exc:  # user-facing API error
+                self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+                return
+            self._json(HTTPStatus.OK, {"db_path": resolved, "cases": data})
+            return
+
+        self._json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path not in {"/init", "/add", "/done"}:
+            self._json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+            return
+
+        self._require_auth()
+        if not self._authorized:
+            return
+
+        payload = self._read_json_body()
+        if payload is None:
+            return
+
+        req_db_path = payload.get("db_path") if isinstance(payload, dict) else None
+        try:
+            db_path = self.server.policy.resolve_db_path(req_db_path)
+        except Exception as exc:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+
+        try:
+            if self.path == "/init":
+                init_sim_db(db_path)
+                self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path})
+                return
+
+            if self.path == "/add":
+                add_sim_item(
+                    case=payload["case"],
+                    inp=payload.get("inp"),
+                    input_files=payload.get("input_files"),
+                    bin_name=payload["bin_name"],
+                    status=payload["status"],
+                    db_path=db_path,
+                    note=payload.get("note"),
+                    work_dir=payload.get("work_dir"),
+                )
+                self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path, "case": payload["case"]})
+                return
+
+            if self.path == "/done":
+                mark_done(case=payload["case"], db_path=db_path)
+                self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path, "case": payload["case"]})
+                return
+
+        except KeyError as exc:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": f"missing field: {exc.args[0]}"})
+        except (ValueError, FileNotFoundError) as exc:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        return
+
+    def _read_json_body(self) -> dict[str, Any] | None:
+        try:
+            raw_len = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(raw_len) if raw_len > 0 else b"{}"
+            payload = json.loads(raw.decode("utf-8")) if raw else {}
+            if not isinstance(payload, dict):
+                raise ValueError("JSON body must be an object")
+            return payload
+        except Exception as exc:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": f"invalid JSON: {exc}"})
+            return None
+
+    def _query_dict(self) -> dict[str, str]:
+        query = parse_qs(urlsplit(self.path).query, keep_blank_values=True)
+        out: dict[str, str] = {}
+        for k, vals in query.items():
+            if vals:
+                out[k] = vals[0]
+        return out
+
+    def _require_auth(self) -> None:
+        self._authorized = self.server.policy.is_authorized(self.headers.get("Authorization"))
+        if not self._authorized:
+            self._json(HTTPStatus.UNAUTHORIZED, {"error": "unauthorized"})
+
+    def _json(self, status: HTTPStatus, obj: dict[str, Any]) -> None:
+        data = json.dumps(obj, ensure_ascii=False).encode("utf-8")
+        self.send_response(int(status))
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def _norm(path: str) -> str:
+    return os.path.realpath(os.path.abspath(os.path.expanduser(path)))
+
+
+def _is_within_base(path: str, base_dir: str) -> bool:
+    try:
+        common = os.path.commonpath([path, base_dir])
+    except ValueError:
+        return False
+    return common == base_dir
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="mini_sim_db HTTP server")
+    p.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
+    p.add_argument("--port", type=int, default=8765, help="Bind port (default: 8765)")
+    p.add_argument("--db", default=DEFAULT_DB_PATH, help="Default DB path (default: ~/sim_db.csv)")
+    p.add_argument("--allowed-db-path", default=None, help="Optional exact writable DB path")
+    p.add_argument("--allowed-base-dir", default=None, help="Optional writable base directory")
+    p.add_argument("--token", default=None, help="Bearer token (or use SIM_DB_API_TOKEN env)")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    token = args.token or os.getenv("SIM_DB_API_TOKEN")
+    if not token:
+        raise SystemExit("Missing token. Set --token or SIM_DB_API_TOKEN")
+
+    policy = SecurityPolicy(
+        token=token,
+        default_db_path=args.db,
+        allowed_db_path=args.allowed_db_path,
+        allowed_base_dir=args.allowed_base_dir,
+    )
+    server = SimDbApiServer((args.host, args.port), policy)
+    print(f"Serving mini_sim_db API at http://{args.host}:{args.port}")
+    print(f"Default DB path: {policy.default_db_path}")
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sim_db_server.py
+++ b/sim_db_server.py
@@ -230,6 +230,7 @@ class SimDbRequestHandler(BaseHTTPRequestHandler):
                 db_path=db_path,
                 note=payload.get("note"),
                 work_dir=payload.get("work_dir"),
+                extra_params=payload.get("extra_params"),
             )
             run_host = payload.get("run_host")
             if run_host:

--- a/sim_db_server.py
+++ b/sim_db_server.py
@@ -1,6 +1,6 @@
 """HTTP host for mini_sim_db.
 
-Small stdlib-only JSON API around sim_db.py for centralized case updates.
+Stdlib-only JSON API around sim_db.py for centralized CRUD updates.
 """
 
 from __future__ import annotations
@@ -8,13 +8,27 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from datetime import datetime
 from pathlib import Path
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from urllib.parse import parse_qs, urlsplit
 
-from sim_db import DEFAULT_DB_PATH, add_sim_item, init_sim_db, list_items, mark_done
+from sim_db import (
+    ALLOWED_STATUS,
+    DEFAULT_DB_PATH,
+    add_sim_item,
+    del_cases,
+    init_sim_db,
+    list_items,
+    mark_done,
+    upd_cases,
+)
+
+
+def _now_iso() -> str:
+    return datetime.now().isoformat(timespec="milliseconds")
 
 
 class SecurityPolicy:
@@ -43,7 +57,6 @@ class SecurityPolicy:
 
         wanted = _norm(requested_db_path)
 
-        # safest default: only configured default DB path is writable
         if self.allowed_db_path is None and self.allowed_base_dir is None:
             if wanted == self.default_db_path:
                 return wanted
@@ -76,24 +89,61 @@ class SimDbRequestHandler(BaseHTTPRequestHandler):
             self._require_auth()
             if not self._authorized:
                 return
+
             query = self._query_dict()
-            db_path = query.get("db_path")
             try:
-                resolved = self.server.policy.resolve_db_path(db_path)
-                data = list_items(resolved)
-            except Exception as exc:  # user-facing API error
+                db_path = self.server.policy.resolve_db_path(query.get("db_path"))
+                case = self._case_from_path()
+                data = list_items(db_path)
+                if case:
+                    if case not in data:
+                        self._json(HTTPStatus.NOT_FOUND, {"error": f"case not found: {case}"})
+                        return
+                    self._json(HTTPStatus.OK, {"db_path": db_path, "case": case, "item": data[case]})
+                    return
+                self._json(HTTPStatus.OK, {"db_path": db_path, "cases": data})
+            except Exception as exc:
                 self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
-                return
-            self._json(HTTPStatus.OK, {"db_path": resolved, "cases": data})
             return
 
         self._json(HTTPStatus.NOT_FOUND, {"error": "not found"})
 
     def do_POST(self) -> None:  # noqa: N802
-        if self.path not in {"/init", "/add", "/done"}:
-            self._json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+        if self.path == "/init":
+            self._require_auth()
+            if not self._authorized:
+                return
+            payload = self._read_json_body()
+            if payload is None:
+                return
+            try:
+                db_path = self.server.policy.resolve_db_path(payload.get("db_path"))
+                init_sim_db(db_path)
+                self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path})
+            except Exception as exc:
+                self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
             return
 
+        if self.path in {"/add", "/done", "/update", "/delete"}:
+            self._legacy_mutating_routes()
+            return
+
+        if self.path == "/cases":
+            self._require_auth()
+            if not self._authorized:
+                return
+            payload = self._read_json_body()
+            if payload is None:
+                return
+            self._create_case(payload)
+            return
+
+        self._json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+
+    def do_PATCH(self) -> None:  # noqa: N802
+        if not self.path.startswith("/cases/"):
+            self._json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+            return
         self._require_auth()
         if not self._authorized:
             return
@@ -102,41 +152,119 @@ class SimDbRequestHandler(BaseHTTPRequestHandler):
         if payload is None:
             return
 
-        req_db_path = payload.get("db_path") if isinstance(payload, dict) else None
-        try:
-            db_path = self.server.policy.resolve_db_path(req_db_path)
-        except Exception as exc:
-            self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+        case = self._case_from_path()
+        if not case:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": "missing case in path"})
             return
 
+        self._update_case(case, payload)
+
+    def do_DELETE(self) -> None:  # noqa: N802
+        if not self.path.startswith("/cases/"):
+            self._json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+            return
+        self._require_auth()
+        if not self._authorized:
+            return
+
+        case = self._case_from_path()
+        if not case:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": "missing case in path"})
+            return
+
+        query = self._query_dict()
+        req_db = query.get("db_path")
         try:
-            if self.path == "/init":
-                init_sim_db(db_path)
-                self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path})
-                return
+            db_path = self.server.policy.resolve_db_path(req_db)
+            del_cases(db_path, [case])
+            self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path, "case": case})
+        except Exception as exc:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
 
-            if self.path == "/add":
-                add_sim_item(
-                    case=payload["case"],
-                    inp=payload.get("inp"),
-                    input_files=payload.get("input_files"),
-                    bin_name=payload["bin_name"],
-                    status=payload["status"],
-                    db_path=db_path,
-                    note=payload.get("note"),
-                    work_dir=payload.get("work_dir"),
-                )
-                self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path, "case": payload["case"]})
-                return
+    def _legacy_mutating_routes(self) -> None:
+        self._require_auth()
+        if not self._authorized:
+            return
+        payload = self._read_json_body()
+        if payload is None:
+            return
 
-            if self.path == "/done":
-                mark_done(case=payload["case"], db_path=db_path)
-                self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path, "case": payload["case"]})
+        if self.path == "/add":
+            self._create_case(payload)
+            return
+        if self.path == "/done":
+            case = payload.get("case")
+            if not case:
+                self._json(HTTPStatus.BAD_REQUEST, {"error": "missing field: case"})
                 return
+            self._update_case(case, {"fields": {"status": "done"}, **payload})
+            return
+        if self.path == "/update":
+            case = payload.get("case")
+            if not case:
+                self._json(HTTPStatus.BAD_REQUEST, {"error": "missing field: case"})
+                return
+            self._update_case(case, payload)
+            return
+        if self.path == "/delete":
+            case = payload.get("case")
+            if not case:
+                self._json(HTTPStatus.BAD_REQUEST, {"error": "missing field: case"})
+                return
+            try:
+                db_path = self.server.policy.resolve_db_path(payload.get("db_path"))
+                del_cases(db_path, [case])
+                self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path, "case": case})
+            except Exception as exc:
+                self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
 
+    def _create_case(self, payload: dict[str, Any]) -> None:
+        try:
+            db_path = self.server.policy.resolve_db_path(payload.get("db_path"))
+            add_sim_item(
+                case=payload["case"],
+                inp=payload.get("inp"),
+                input_files=payload.get("input_files"),
+                bin_name=payload["bin_name"],
+                status=payload["status"],
+                db_path=db_path,
+                note=payload.get("note"),
+                work_dir=payload.get("work_dir"),
+            )
+            run_host = payload.get("run_host")
+            if run_host:
+                upd_cases(db_path, {payload["case"]: {"run_host": str(run_host)}})
+            self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path, "case": payload["case"]})
         except KeyError as exc:
             self._json(HTTPStatus.BAD_REQUEST, {"error": f"missing field: {exc.args[0]}"})
-        except (ValueError, FileNotFoundError) as exc:
+        except Exception as exc:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+
+    def _update_case(self, case: str, payload: dict[str, Any]) -> None:
+        try:
+            db_path = self.server.policy.resolve_db_path(payload.get("db_path"))
+            fields = payload.get("fields")
+            if fields is None:
+                fields = {k: v for k, v in payload.items() if k not in {"case", "db_path", "run_host"}}
+            if not isinstance(fields, dict) or not fields:
+                raise ValueError("fields must be a non-empty object")
+
+            status = fields.get("status")
+            if status is not None:
+                if status not in ALLOWED_STATUS:
+                    allowed = ", ".join(sorted(ALLOWED_STATUS))
+                    raise ValueError(f"Invalid status '{status}'. Allowed: {allowed}")
+                fields["state_changed_at"] = _now_iso()
+
+            fields["updated_at"] = _now_iso()
+
+            run_host = payload.get("run_host")
+            if run_host:
+                fields["run_host"] = str(run_host)
+
+            upd_cases(db_path, {case: fields})
+            self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path, "case": case, "updated": sorted(fields.keys())})
+        except Exception as exc:
             self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
 
     def log_message(self, fmt: str, *args: Any) -> None:
@@ -161,6 +289,13 @@ class SimDbRequestHandler(BaseHTTPRequestHandler):
             if vals:
                 out[k] = vals[0]
         return out
+
+    def _case_from_path(self) -> str | None:
+        path = urlsplit(self.path).path
+        parts = [p for p in path.split("/") if p]
+        if len(parts) >= 2 and parts[0] == "cases":
+            return parts[1]
+        return None
 
     def _require_auth(self) -> None:
         self._authorized = self.server.policy.is_authorized(self.headers.get("Authorization"))

--- a/sim_db_server.py
+++ b/sim_db_server.py
@@ -8,12 +8,13 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import threading
 from datetime import datetime
 from pathlib import Path
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
-from urllib.parse import parse_qs, urlsplit
+from urllib.parse import parse_qs, unquote, urlsplit
 
 from sim_db import (
     ALLOWED_STATUS,
@@ -74,6 +75,7 @@ class SecurityPolicy:
 class SimDbApiServer(ThreadingHTTPServer):
     def __init__(self, server_address: tuple[str, int], policy: SecurityPolicy) -> None:
         self.policy = policy
+        self.mutation_lock = threading.Lock()
         super().__init__(server_address, SimDbRequestHandler)
 
 
@@ -118,7 +120,8 @@ class SimDbRequestHandler(BaseHTTPRequestHandler):
                 return
             try:
                 db_path = self.server.policy.resolve_db_path(payload.get("db_path"))
-                init_sim_db(db_path)
+                with self.server.mutation_lock:
+                    init_sim_db(db_path)
                 self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path})
             except Exception as exc:
                 self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
@@ -176,7 +179,8 @@ class SimDbRequestHandler(BaseHTTPRequestHandler):
         req_db = query.get("db_path")
         try:
             db_path = self.server.policy.resolve_db_path(req_db)
-            del_cases(db_path, [case])
+            with self.server.mutation_lock:
+                del_cases(db_path, [case])
             self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path, "case": case})
         except Exception as exc:
             self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
@@ -213,7 +217,8 @@ class SimDbRequestHandler(BaseHTTPRequestHandler):
                 return
             try:
                 db_path = self.server.policy.resolve_db_path(payload.get("db_path"))
-                del_cases(db_path, [case])
+                with self.server.mutation_lock:
+                    del_cases(db_path, [case])
                 self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path, "case": case})
             except Exception as exc:
                 self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
@@ -221,20 +226,21 @@ class SimDbRequestHandler(BaseHTTPRequestHandler):
     def _create_case(self, payload: dict[str, Any]) -> None:
         try:
             db_path = self.server.policy.resolve_db_path(payload.get("db_path"))
-            add_sim_item(
-                case=payload["case"],
-                inp=payload.get("inp"),
-                input_files=payload.get("input_files"),
-                bin_name=payload["bin_name"],
-                status=payload["status"],
-                db_path=db_path,
-                note=payload.get("note"),
-                work_dir=payload.get("work_dir"),
-                extra_params=payload.get("extra_params"),
-            )
-            run_host = payload.get("run_host")
-            if run_host:
-                upd_cases(db_path, {payload["case"]: {"run_host": str(run_host)}})
+            with self.server.mutation_lock:
+                add_sim_item(
+                    case=payload["case"],
+                    inp=payload.get("inp"),
+                    input_files=payload.get("input_files"),
+                    bin_name=payload["bin_name"],
+                    status=payload["status"],
+                    db_path=db_path,
+                    note=payload.get("note"),
+                    work_dir=payload.get("work_dir"),
+                    extra_params=payload.get("extra_params"),
+                )
+                run_host = payload.get("run_host")
+                if run_host:
+                    upd_cases(db_path, {payload["case"]: {"run_host": str(run_host)}})
             self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path, "case": payload["case"]})
         except KeyError as exc:
             self._json(HTTPStatus.BAD_REQUEST, {"error": f"missing field: {exc.args[0]}"})
@@ -263,7 +269,8 @@ class SimDbRequestHandler(BaseHTTPRequestHandler):
             if run_host:
                 fields["run_host"] = str(run_host)
 
-            upd_cases(db_path, {case: fields})
+            with self.server.mutation_lock:
+                upd_cases(db_path, {case: fields})
             self._json(HTTPStatus.OK, {"ok": True, "db_path": db_path, "case": case, "updated": sorted(fields.keys())})
         except Exception as exc:
             self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
@@ -295,7 +302,7 @@ class SimDbRequestHandler(BaseHTTPRequestHandler):
         path = urlsplit(self.path).path
         parts = [p for p in path.split("/") if p]
         if len(parts) >= 2 and parts[0] == "cases":
-            return parts[1]
+            return unquote(parts[1])
         return None
 
     def _require_auth(self) -> None:

--- a/sim_db_server.py
+++ b/sim_db_server.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from pathlib import Path
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
@@ -176,15 +177,17 @@ class SimDbRequestHandler(BaseHTTPRequestHandler):
 
 
 def _norm(path: str) -> str:
-    return os.path.realpath(os.path.abspath(os.path.expanduser(path)))
+    return str(Path(path).expanduser().resolve())
 
 
 def _is_within_base(path: str, base_dir: str) -> bool:
+    target = Path(path).expanduser().resolve()
+    base = Path(base_dir).expanduser().resolve()
     try:
-        common = os.path.commonpath([path, base_dir])
+        target.relative_to(base)
+        return True
     except ValueError:
         return False
-    return common == base_dir
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/test_sim_db.py
+++ b/test_sim_db.py
@@ -88,6 +88,7 @@ class TestSimpleCliFunctions(unittest.TestCase):
             db_path=self.db_path,
             note='from test',
             work_dir='/tmp/case001',
+            extra_params='{"alpha": 1, "beta": "x"}',
         )
 
         table = list_items(self.db_path)
@@ -96,6 +97,7 @@ class TestSimpleCliFunctions(unittest.TestCase):
         self.assertEqual(table['case001']['input_files'], 'job.inp;mesh.inp')
         self.assertEqual(table['case001']['note'], 'from test')
         self.assertEqual(table['case001']['work_dir'], '/tmp/case001')
+        self.assertEqual(table['case001']['extra_params'], '{"alpha": 1, "beta": "x"}')
         self.assertEqual(table['case001']['state_changed_at'], table['case001']['updated_at'])
 
         before_change = table['case001']['state_changed_at']
@@ -154,6 +156,7 @@ class TestSimpleCliFunctions(unittest.TestCase):
                 'bin',
                 'inp',
                 'input_files',
+                'extra_params',
                 'status',
                 'note',
                 'notes',
@@ -212,6 +215,8 @@ class TestCliSubprocess(unittest.TestCase):
             '--input-file', 'extra2.inp',
             '--bin', 'solver',
             '--work-dir', '/tmp/c2',
+            '--extra-param', 'threads=8',
+            '--extra-param', 'precision=double',
             '--status', 'start',
             '--note', 'short note',
         )
@@ -223,7 +228,22 @@ class TestCliSubprocess(unittest.TestCase):
         self.assertIn("'input_files': 'base.inp;extra1.inp;extra2.inp'", r_list.stdout)
         self.assertIn("'note': 'short note'", r_list.stdout)
         self.assertIn("'work_dir': '/tmp/c2'", r_list.stdout)
+        self.assertIn("'extra_params': '{\"precision\": \"double\", \"threads\": \"8\"}'", r_list.stdout)
         self.assertIn("'state_changed_at': '", r_list.stdout)
+
+    def test_cli_extra_params_conflict_rejected(self):
+        self.assertEqual(self._run('init').returncode, 0)
+        r_add = self._run(
+            'add',
+            '--case', 'c3',
+            '--inp', 'base.inp',
+            '--bin', 'solver',
+            '--status', 'start',
+            '--extra-param', 'threads=8',
+            '--extra-params', '{"threads": 16}',
+        )
+        self.assertNotEqual(r_add.returncode, 0)
+        self.assertIn('Use either --extra-params or --extra-param, not both', r_add.stderr)
 
 
 if __name__ == '__main__':

--- a/test_sim_db_rest.py
+++ b/test_sim_db_rest.py
@@ -1,0 +1,100 @@
+import os
+import tempfile
+import threading
+import unittest
+
+from sim_db_client import SimDbClient
+from sim_db_server import SecurityPolicy, SimDbApiServer
+
+
+class RestServerTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_default = os.path.join(self.tmp.name, "default.csv")
+        self.db_other = os.path.join(self.tmp.name, "other.csv")
+        self.token = "test-token"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _start_server(self, *, allowed_db_path=None, allowed_base_dir=None):
+        policy = SecurityPolicy(
+            token=self.token,
+            default_db_path=self.db_default,
+            allowed_db_path=allowed_db_path,
+            allowed_base_dir=allowed_base_dir,
+        )
+        server = SimDbApiServer(("127.0.0.1", 0), policy)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        url = f"http://127.0.0.1:{server.server_port}"
+        return server, thread, url
+
+    def test_client_roundtrip_default_db(self):
+        server, thread, url = self._start_server()
+        try:
+            client = SimDbClient(base_url=url, token=self.token)
+            self.assertTrue(client.health()["ok"])
+
+            out = client.init()
+            self.assertTrue(out["ok"])
+            self.assertTrue(os.path.exists(self.db_default))
+
+            client.add(
+                case="c1",
+                inp="job.inp",
+                input_files=["job.inp", "mesh.inp"],
+                bin_name="solver",
+                status="start",
+                note="remote submit",
+                work_dir="/work/c1",
+            )
+            table = client.list()
+            self.assertIn("c1", table["cases"])
+            self.assertEqual(table["cases"]["c1"]["status"], "start")
+
+            client.done(case="c1")
+            table2 = client.list()
+            self.assertEqual(table2["cases"]["c1"]["status"], "done")
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    def test_unauthorized_rejected(self):
+        server, thread, url = self._start_server()
+        try:
+            bad = SimDbClient(base_url=url, token="wrong")
+            with self.assertRaises(RuntimeError):
+                bad.init()
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    def test_custom_db_denied_by_default(self):
+        server, thread, url = self._start_server()
+        try:
+            client = SimDbClient(base_url=url, token=self.token)
+            client.init()
+            with self.assertRaises(RuntimeError):
+                client.init(db_path=self.db_other)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    def test_custom_db_allowed_with_base_dir(self):
+        server, thread, url = self._start_server(allowed_base_dir=self.tmp.name)
+        try:
+            client = SimDbClient(base_url=url, token=self.token)
+            client.init(db_path=self.db_other)
+            self.assertTrue(os.path.exists(self.db_other))
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_sim_db_rest.py
+++ b/test_sim_db_rest.py
@@ -2,8 +2,11 @@ import os
 import socket
 import tempfile
 import threading
+import time
 import unittest
+from unittest import mock
 
+import sim_db_server
 from sim_db import list_items
 from sim_db_client import SimDbClient
 from sim_db_server import SecurityPolicy, SimDbApiServer
@@ -117,6 +120,20 @@ class RestServerTestCase(unittest.TestCase):
             server.server_close()
             thread.join(timeout=2)
 
+    def test_dual_write_does_not_fallback_on_http_error(self):
+        server, thread, url = self._start_server()
+        try:
+            bad = SimDbClient(base_url=url, token="wrong", local_db_path=self.local_db)
+            with self.assertRaisesRegex(RuntimeError, "HTTP 401"):
+                bad.create(case="auth-c1", inp="job.inp", bin_name="solver", status="start")
+
+            local_table = list_items(self.local_db)
+            self.assertIn("auth-c1", local_table)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
     def test_custom_db_denied_by_default(self):
         server, thread, url = self._start_server()
         try:
@@ -135,6 +152,74 @@ class RestServerTestCase(unittest.TestCase):
             client = SimDbClient(base_url=url, token=self.token, local_db_path=self.local_db)
             client.init(db_path=self.db_other)
             self.assertTrue(os.path.exists(self.db_other))
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    def test_case_path_roundtrip_with_url_escaped_case_id(self):
+        server, thread, url = self._start_server()
+        try:
+            client = SimDbClient(base_url=url, token=self.token, local_db_path=self.local_db)
+            client.init()
+            case = "folder/name with space"
+            client.create(case=case, inp="job.inp", bin_name="solver", status="start")
+
+            one = client.read(case=case)
+            self.assertEqual(one["case"], case)
+
+            client.update(case=case, fields={"note": "updated"})
+            one2 = client.read(case=case)
+            self.assertEqual(one2["item"]["note"], "updated")
+
+            client.delete(case=case)
+            all_items = client.list()
+            self.assertNotIn(case, all_items["cases"])
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    def test_mutations_are_serialized_under_threaded_server(self):
+        server, thread, url = self._start_server()
+        overlap_detected = threading.Event()
+        gate = threading.Lock()
+        original_add = sim_db_server.add_sim_item
+
+        def guarded_add(*args, **kwargs):
+            if not gate.acquire(blocking=False):
+                overlap_detected.set()
+            else:
+                try:
+                    time.sleep(0.1)
+                    return original_add(*args, **kwargs)
+                finally:
+                    gate.release()
+
+        try:
+            with mock.patch("sim_db_server.add_sim_item", side_effect=guarded_add):
+                client = SimDbClient(base_url=url, token=self.token, enable_local_write=False)
+                client.init()
+
+                errors: list[Exception] = []
+
+                def _create(case: str, inp: str) -> None:
+                    try:
+                        client.create(case=case, inp=inp, bin_name="solver", status="start")
+                    except Exception as exc:  # pragma: no cover - defensive for thread join assertions
+                        errors.append(exc)
+
+                t1 = threading.Thread(target=_create, args=("c1", "a.inp"))
+                t2 = threading.Thread(target=_create, args=("c2", "b.inp"))
+                t1.start()
+                t2.start()
+                t1.join(timeout=2)
+                t2.join(timeout=2)
+
+                self.assertFalse(t1.is_alive())
+                self.assertFalse(t2.is_alive())
+                self.assertEqual(errors, [])
+                self.assertFalse(overlap_detected.is_set(), "mutating requests overlapped unexpectedly")
         finally:
             server.shutdown()
             server.server_close()

--- a/test_sim_db_rest.py
+++ b/test_sim_db_rest.py
@@ -51,6 +51,7 @@ class RestServerTestCase(unittest.TestCase):
                 status="start",
                 note="remote submit",
                 work_dir="/work/c1",
+                extra_params='{"threads": 8, "precision": "double"}',
             )
             self.assertTrue(created["ok"])
             self.assertTrue(created["remote_ok"])
@@ -59,6 +60,7 @@ class RestServerTestCase(unittest.TestCase):
             one = client.read(case="c1")
             self.assertEqual(one["item"]["status"], "start")
             self.assertEqual(one["item"]["run_host"], socket.gethostname())
+            self.assertEqual(one["item"]["extra_params"], '{"threads": 8, "precision": "double"}')
 
             updated = client.update(case="c1", fields={"note": "patched", "status": "restart"})
             self.assertTrue(updated["ok"])
@@ -93,6 +95,7 @@ class RestServerTestCase(unittest.TestCase):
             inp="job.inp",
             bin_name="solver",
             status="start",
+            extra_params='{"mode": "offline"}',
         )
         self.assertTrue(out["ok"])
         self.assertFalse(out["remote_ok"])
@@ -101,6 +104,7 @@ class RestServerTestCase(unittest.TestCase):
         local_table = list_items(self.local_db)
         self.assertIn("offline-c1", local_table)
         self.assertEqual(local_table["offline-c1"]["run_host"], socket.gethostname())
+        self.assertEqual(local_table["offline-c1"]["extra_params"], '{"mode": "offline"}')
 
     def test_unauthorized_rejected(self):
         server, thread, url = self._start_server()

--- a/test_sim_db_rest.py
+++ b/test_sim_db_rest.py
@@ -1,8 +1,10 @@
 import os
+import socket
 import tempfile
 import threading
 import unittest
 
+from sim_db import list_items
 from sim_db_client import SimDbClient
 from sim_db_server import SecurityPolicy, SimDbApiServer
 
@@ -12,6 +14,7 @@ class RestServerTestCase(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         self.db_default = os.path.join(self.tmp.name, "default.csv")
         self.db_other = os.path.join(self.tmp.name, "other.csv")
+        self.local_db = os.path.join(self.tmp.name, "local.csv")
         self.token = "test-token"
 
     def tearDown(self):
@@ -30,17 +33,17 @@ class RestServerTestCase(unittest.TestCase):
         url = f"http://127.0.0.1:{server.server_port}"
         return server, thread, url
 
-    def test_client_roundtrip_default_db(self):
+    def test_client_full_crud_roundtrip_and_run_host(self):
         server, thread, url = self._start_server()
         try:
-            client = SimDbClient(base_url=url, token=self.token)
+            client = SimDbClient(base_url=url, token=self.token, local_db_path=self.local_db)
             self.assertTrue(client.health()["ok"])
 
             out = client.init()
             self.assertTrue(out["ok"])
             self.assertTrue(os.path.exists(self.db_default))
 
-            client.add(
+            created = client.create(
                 case="c1",
                 inp="job.inp",
                 input_files=["job.inp", "mesh.inp"],
@@ -49,22 +52,60 @@ class RestServerTestCase(unittest.TestCase):
                 note="remote submit",
                 work_dir="/work/c1",
             )
-            table = client.list()
-            self.assertIn("c1", table["cases"])
-            self.assertEqual(table["cases"]["c1"]["status"], "start")
+            self.assertTrue(created["ok"])
+            self.assertTrue(created["remote_ok"])
+            self.assertTrue(created["local_ok"])
 
-            client.done(case="c1")
-            table2 = client.list()
-            self.assertEqual(table2["cases"]["c1"]["status"], "done")
+            one = client.read(case="c1")
+            self.assertEqual(one["item"]["status"], "start")
+            self.assertEqual(one["item"]["run_host"], socket.gethostname())
+
+            updated = client.update(case="c1", fields={"note": "patched", "status": "restart"})
+            self.assertTrue(updated["ok"])
+            one2 = client.read(case="c1")
+            self.assertEqual(one2["item"]["note"], "patched")
+            self.assertEqual(one2["item"]["status"], "restart")
+            self.assertEqual(one2["item"]["run_host"], socket.gethostname())
+
+            done = client.done(case="c1")
+            self.assertTrue(done["ok"])
+            one3 = client.read(case="c1")
+            self.assertEqual(one3["item"]["status"], "done")
+
+            deleted = client.delete(case="c1")
+            self.assertTrue(deleted["ok"])
+            all_items = client.list()
+            self.assertNotIn("c1", all_items["cases"])
         finally:
             server.shutdown()
             server.server_close()
             thread.join(timeout=2)
 
+    def test_dual_write_fallback_when_remote_unavailable(self):
+        client = SimDbClient(
+            base_url="http://127.0.0.1:1",
+            token=self.token,
+            local_db_path=self.local_db,
+        )
+
+        out = client.create(
+            case="offline-c1",
+            inp="job.inp",
+            bin_name="solver",
+            status="start",
+        )
+        self.assertTrue(out["ok"])
+        self.assertFalse(out["remote_ok"])
+        self.assertEqual(out["fallback"], "local-only")
+
+        local_table = list_items(self.local_db)
+        self.assertIn("offline-c1", local_table)
+        self.assertEqual(local_table["offline-c1"]["run_host"], socket.gethostname())
+
     def test_unauthorized_rejected(self):
         server, thread, url = self._start_server()
         try:
-            bad = SimDbClient(base_url=url, token="wrong")
+            bad = SimDbClient(base_url=url, token="wrong", local_db_path=self.local_db)
             with self.assertRaises(RuntimeError):
                 bad.init()
         finally:
@@ -75,7 +116,7 @@ class RestServerTestCase(unittest.TestCase):
     def test_custom_db_denied_by_default(self):
         server, thread, url = self._start_server()
         try:
-            client = SimDbClient(base_url=url, token=self.token)
+            client = SimDbClient(base_url=url, token=self.token, local_db_path=self.local_db)
             client.init()
             with self.assertRaises(RuntimeError):
                 client.init(db_path=self.db_other)
@@ -87,7 +128,7 @@ class RestServerTestCase(unittest.TestCase):
     def test_custom_db_allowed_with_base_dir(self):
         server, thread, url = self._start_server(allowed_base_dir=self.tmp.name)
         try:
-            client = SimDbClient(base_url=url, token=self.token)
+            client = SimDbClient(base_url=url, token=self.token, local_db_path=self.local_db)
             client.init(db_path=self.db_other)
             self.assertTrue(os.path.exists(self.db_other))
         finally:

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -1,0 +1,235 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# mini_sim_db tutorial\n",
+    "\n",
+    "This notebook explains the full idea behind `mini_sim_db` and shows practical usage beyond the short README."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1) Design idea\n",
+    "\n",
+    "`mini_sim_db` is intentionally simple:\n",
+    "\n",
+    "- Store simulation run metadata in a CSV file (human-readable, easy to diff, easy to back up).\n",
+    "- Keep a tiny local CLI for direct use in submit/post scripts.\n",
+    "- Offer a small REST layer for centralized/team workflows.\n",
+    "- Reuse one core CSV logic path (`sim_db.py`) from both CLI and server/client code.\n",
+    "\n",
+    "This avoids heavyweight databases while still giving structured run tracking."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2) Schema and fields\n",
+    "\n",
+    "The CSV keeps these fields in stable order:\n",
+    "\n",
+    "- `case`: case ID (primary key style identifier)\n",
+    "- `work_dir`: run working directory\n",
+    "- `bin`: solver/executable label\n",
+    "- `inp`: primary input file\n",
+    "- `input_files`: all input files joined with `;`\n",
+    "- `extra_params`: extra runtime parameters (usually JSON text)\n",
+    "- `run_host`: host that initiated the mutating operation (mainly set by REST client)\n",
+    "- `status`: `start`, `restart`, or `done`\n",
+    "- `note`: short human note\n",
+    "- `notes`: legacy compatibility field\n",
+    "- `state_changed_at`: timestamp for status lifecycle events\n",
+    "- `created_at`: initial creation timestamp\n",
+    "- `updated_at`: last update timestamp\n",
+    "\n",
+    "### `extra_params` in practice\n",
+    "\n",
+    "You can store runtime knobs that are not represented as dedicated columns, for example:\n",
+    "\n",
+    "```json\n",
+    "{\"threads\": 16, \"precision\": \"double\", \"queue\": \"long\"}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3) Local-only workflow (CLI)\n",
+    "\n",
+    "Use this when each machine/user writes its own CSV."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# init\n",
+    "python sim_db.py init\n",
+    "\n",
+    "# add a case with extra params\n",
+    "python sim_db.py add \\\n",
+    "  --case wing_040 \\\n",
+    "  --work-dir /scratch/wing_040 \\\n",
+    "  --inp wing_040.inp \\\n",
+    "  --bin solver_v2 \\\n",
+    "  --extra-param threads=16 \\\n",
+    "  --extra-param precision=double \\\n",
+    "  --status start\n",
+    "\n",
+    "# done + list\n",
+    "python sim_db.py done --case wing_040\n",
+    "python sim_db.py list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4) Remote workflow (REST server + client)\n",
+    "\n",
+    "Use this when you want one central DB and access from many machines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# terminal A: server\n",
+    "export SIM_DB_API_TOKEN='replace-me'\n",
+    "python sim_db_server.py --host 127.0.0.1 --port 8765 --db ~/sim_db.csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# terminal B: client\n",
+    "export SIM_DB_API_TOKEN='replace-me'\n",
+    "python sim_db_client.py --url http://127.0.0.1:8765 init\n",
+    "python sim_db_client.py --url http://127.0.0.1:8765 create \\\n",
+    "  --case c100 --inp c100.inp --bin solver --status start \\\n",
+    "  --extra-params '{\"threads\":8,\"mode\":\"fast\"}'\n",
+    "python sim_db_client.py --url http://127.0.0.1:8765 done --case c100\n",
+    "python sim_db_client.py --url http://127.0.0.1:8765 list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Local durability + `run_host`\n",
+    "\n",
+    "By default, mutating client operations use dual-write behavior:\n",
+    "\n",
+    "1. write to local mirror CSV (`~/.sim_db_client_local.csv`)\n",
+    "2. attempt remote write\n",
+    "\n",
+    "If remote is temporarily down, operation can still be kept locally.\n",
+    "\n",
+    "`run_host` is set from the client side to record which machine initiated a write."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5) Security notes\n",
+    "\n",
+    "Keep this lightweight but not open-by-default:\n",
+    "\n",
+    "- Always set and require `SIM_DB_API_TOKEN` (or pass `--token`).\n",
+    "- Bind to loopback (`127.0.0.1`) unless you explicitly need remote access.\n",
+    "- If exposing remotely, use firewall/Tailscale/VPN and strict path allowlists.\n",
+    "- Prefer environment variables for tokens over hardcoding them in scripts.\n",
+    "- Keep `--allowed-db-path` / `--allowed-base-dir` tight on server side."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6) Practical examples\n",
+    "\n",
+    "### Example A: submit script integration\n",
+    "\n",
+    "Record `start` before submission, then `done` after post-processing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!/usr/bin/env bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "CASE=case_123\n",
+    "DB=${DB:-$HOME/sim_db.csv}\n",
+    "\n",
+    "python sim_db.py init --db \"$DB\"\n",
+    "python sim_db.py add --case \"$CASE\" --inp \"${CASE}.inp\" --bin solver --status start --db \"$DB\"\n",
+    "# ... submit workload ...\n",
+    "python sim_db.py done --case \"$CASE\" --db \"$DB\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example B: track restarts clearly\n",
+    "\n",
+    "Use `status=restart` with a short note so later analysis is easier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "python sim_db.py add \\\n",
+    "  --case case_777 \\\n",
+    "  --inp case_777.inp \\\n",
+    "  --bin solver_v3 \\\n",
+    "  --status restart \\\n",
+    "  --note 'rerun after mesh repair'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "If you only need the quick commands, go back to `README.md`.\n",
+    "If you need structure and context, keep this notebook as your reference."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a secure stdlib REST server/client for centralized `mini_sim_db` usage
- expand REST support to full CRUD while reusing existing `sim_db.py` helpers
- record `run_host` for REST-originated operations
- support local dual-write fallback when remote REST is unavailable
- add `extra_params` for parameter-driven program runs
- simplify README and move fuller documentation into `tutorial.ipynb`

## Details
This PR keeps the original local CSV workflow intact while adding a thin host/client layer for managing simulation records across workstations and clusters.

### Added
- `sim_db_server.py`
- `sim_db_client.py`
- `tutorial.ipynb`
- REST tests and documentation updates

### REST behavior
- bearer-token protected host
- safe writable-path restrictions
- CRUD endpoints for create/read/update/delete
- compatibility routes kept where useful

### Data model additions
- `run_host`: records the workstation/cluster hostname for REST-originated writes
- `extra_params`: stores additional runtime keyword parameters for non-file-based runs

### Reliability
- mutating client REST operations can also write to a local mirror DB so records are not lost during remote outages

## Verification
- `python3 -m unittest -v`
- all tests passing locally
